### PR TITLE
Fix README bullet capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 - 👋 Hi, I’m @MarkusPietruska
 - 👀 I’m interested in statistics and data science
-- 🌱 I’m currently learning python for my degree in business administration
+- 🌱 I’m currently learning Python for my degree in business administration.
 - 💞️ I’m looking to collaborate on statistical tests for neural networks
 - 📫 How to reach me markus.pietruska@icloud.com
 - 😄 Pronouns: he/him


### PR DESCRIPTION
## Summary
- fix capitalization of "Python" in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed4af9038832089b1092bdf89d03e